### PR TITLE
Small changes to the readme files for some YSMenu carts

### DIFF
--- a/files/YSMenu/r4i-gold.com_V1.4.1-1.4.4/README.txt
+++ b/files/YSMenu/r4i-gold.com_V1.4.1-1.4.4/README.txt
@@ -6,7 +6,6 @@ YSMenu instructions:
   1. download R4i-SDHC YSMenu
   1. extract R4i-SDHC YSMenu to SD
   1. download `R4.dat` from `/YSMenu/DEMON_common` and replace the one extracted to SD
-  1. rename `YSMenu.nds` to `_BOOT_DS.nds`
 
 
 

--- a/files/YSMenu/r4i-gold.eu/readme.txt
+++ b/files/YSMenu/r4i-gold.eu/readme.txt
@@ -4,4 +4,3 @@ YSMenu instructions:
   1. download R4i-SDHC YSMenu
   1. extract R4i-SDHC YSMenu to SD
   1. download `R4.dat` from `/YSMenu/DEMON_common` and replace the one extracted to SD
-  1. rename `YSMenu.nds` to `_BOOT_DS.nds`

--- a/files/YSMenu/r4imax.com/readme.txt
+++ b/files/YSMenu/r4imax.com/readme.txt
@@ -8,5 +8,3 @@ YSMenu instructions (with bootloader):
   1. download R4i-SDHC YSMenu
   1. extract R4i-SDHC YSMenu to SD
   1. download `R4.dat` from `/YSMenu/DEMON_common` and replace the one extracted to SD
-  1. rename `YSMenu.nds` to `_BOOT_DS.nds`
-  

--- a/files/YSMenu/r4isdhc.com/readme.md
+++ b/files/YSMenu/r4isdhc.com/readme.md
@@ -2,7 +2,6 @@ YSMenu instructions (2014-2020):
   1. download R4i-SDHC YSMenu
   1. extract R4i-SDHC YSMenu to SD
   1. download `R4.dat` from `/YSMenu/DEMON_common` and replace the one extracted to SD
-  1. rename `YSMenu.nds` to `_BOOT_DS.nds`
 
 Christmas Edition, Upgrade V1.4 instructions:
   1. download relevant kernel


### PR DESCRIPTION
Noticed that some of the carts still have the step to rename ysmenu.nds to _boot_ds.nds in their readme files. Quick edit so that it no longer includes this step seeing as the bootloader now boots from ttmenu.dat