### PR TITLE
Add BL2CK carts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ These carts may support BL2CK OS. Only these carts are confirmed to actually wor
   - r4isdhc.in 2014
   - R4i Gold 3DS Plus with faulty DS mode
   - r4-pro.com carts
-  - r4dspro.com / unlabelled yellow pcb carts
+  - r4dspro.com carts
 - Amaze3DS version:
   - r4igold.cc Wood 
   - Amaze3DS (use the Amaze3DS version)

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ These carts may support BL2CK OS. Only these carts are confirmed to actually wor
   - r4isdhc.in 2014
   - R4i Gold 3DS Plus with faulty DS mode
   - r4-pro.com carts
+  - r4dspro.com / unlabelled yellow pcb carts
 - Amaze3DS version:
   - r4igold.cc Wood 
   - Amaze3DS (use the Amaze3DS version)


### PR DESCRIPTION
Adds the r4dspro.com carts and the 'R4DS Pro' carts to the BL2CK compatibility list. Wasn't sure whether to separate them or not seeing as they appear to be the same cart.